### PR TITLE
JSON Schema v3 improvements and unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: false
+language: python
+python:
+- '3.5'
+install:
+- travis_retry pip install -r requirements.txt
+script:
+- py.test tests

--- a/json/v3/example/example.json
+++ b/json/v3/example/example.json
@@ -22,7 +22,7 @@
       "Identifier": {
          "ID": "10.1016/j.ijmedinf.2009.08.006",
          "IDScheme": "doi",
-         "IDURL": "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
+         "IDURL": "https://doi.org/10.1016/j.ijmedinf.2009.08.006"
       },
       "Type": {
          "Name": "literature",
@@ -35,9 +35,9 @@
             "Name": "Dr Juanita Fernando",
             "Identifier": [
                {
-                  "ID": "10.1016/j.ijmedinf.2009.08.006",
-                  "IDScheme": "doi",
-                  "IDURL": "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
+                  "ID": "0000-0002-1825-0097",
+                  "IDScheme": "orcid",
+                  "IDURL": "https://orcid.org/0000-0002-1825-0097"
                }
             ]
          },
@@ -45,9 +45,9 @@
             "Name": "Dr Juanita Fernando",
             "Identifier": [
                {
-                  "ID": "10.1016/j.ijmedinf.2009.08.006",
-                  "IDScheme": "doi",
-                  "IDURL": "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
+                  "ID": "0000-0002-1825-0097",
+                  "IDScheme": "orcid",
+                  "IDURL": "https://orcid.org/0000-0002-1825-0097"
                }
             ]
          }
@@ -60,7 +60,7 @@
                {
                   "ID": "10.1016/j.ijmedinf.2009.08.006",
                   "IDScheme": "doi",
-                  "IDURL": "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
+                  "IDURL": "https://doi.org/10.1016/j.ijmedinf.2009.08.006"
                }
             ]
          }
@@ -70,7 +70,7 @@
       "Identifier": {
          "ID": "10.1016/j.ijmedinf.2009.08.006",
          "IDScheme": "doi",
-         "IDURL": "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
+         "IDURL": "https://doi.org/10.1016/j.ijmedinf.2009.08.006"
       },
       "Type": {
          "Name": "literature",
@@ -83,9 +83,9 @@
             "Name": "Dr Juanita Fernando",
             "Identifier": [
                {
-                  "ID": "10.1016/j.ijmedinf.2009.08.006",
-                  "IDScheme": "doi",
-                  "IDURL": "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
+                  "ID": "0000-0002-1825-0097",
+                  "IDScheme": "orcid",
+                  "IDURL": "https://orcid.org/0000-0002-1825-0097"
                }
             ]
          },
@@ -93,9 +93,9 @@
             "Name": "Dr Juanita Fernando",
             "Identifier": [
                {
-                  "ID": "10.1016/j.ijmedinf.2009.08.006",
-                  "IDScheme": "doi",
-                  "IDURL": "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
+                  "ID": "0000-0002-1825-0097",
+                  "IDScheme": "orcid",
+                  "IDURL": "https://orcid.org/0000-0002-1825-0097"
                }
             ]
          }
@@ -108,7 +108,7 @@
                {
                   "ID": "10.1016/j.ijmedinf.2009.08.006",
                   "IDScheme": "doi",
-                  "IDURL": "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
+                  "IDURL": "https://doi.org/10.1016/j.ijmedinf.2009.08.006"
                }
             ]
          }

--- a/json/v3/example/example.json
+++ b/json/v3/example/example.json
@@ -1,108 +1,116 @@
-{  
-   "LinkPublicationDate":"2017-11-15",
-   "LinkProvider":[  
-      {  
-         "name":"Datasets in Datacite",
-         "identifier":[  
-            {  
-               "ID":"dli_________::datacite",
-               "IDScheme":"dnetIdentifier",
-               "IDURL":"https://www.datacite.org/"
+{
+   "LinkPublicationDate": "2017-11-15",
+   "LinkProvider": [
+      {
+         "Name": "Datasets in Datacite",
+         "Identifier": [
+            {
+               "ID": "dli_________::datacite",
+               "IDScheme": "dnetIdentifier",
+               "IDURL": "https://www.datacite.org/"
             }
          ]
       }
    ],
-   "RelationshipType":{  
-      "Name":"IsRelatedTo",
-      "SubType":"isPreviousVersionOf",
-      "SubTypeSchema":"https://schema.datacite.org/meta/kernel-4.0/metadata.xsd"      
-   },   
+   "RelationshipType": {
+      "Name": "IsRelatedTo",
+      "SubType": "isPreviousVersionOf",
+      "SubTypeSchema": "https://schema.datacite.org/meta/kernel-4.0/metadata.xsd"
+   },
    "LicenseURL": "http://creativecommons.org/publicdomain/zero/1.0",
-    "Source":{  
-      "Identifier":{  
-         "ID":"10.1016/j.ijmedinf.2009.08.006",
-         "IDScheme":"doi",
+   "Source": {
+      "Identifier": {
+         "ID": "10.1016/j.ijmedinf.2009.08.006",
+         "IDScheme": "doi",
          "IDURL": "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
       },
-      "Type":{  
-         "Name":"publication",
-         "SubType":"journal article",
-         "SubTypeSchema":"CASRAI"
+      "Type": {
+         "Name": "literature",
+         "SubType": "journal article",
+         "SubTypeSchema": "CASRAI"
       },
-      "Title":"The health information system security threat lifecycle: an informatics theory.",
-      "Creator":[  
-         {  
-            "Name":"Dr Juanita Fernando",
-            "Identifier":{  
-                 "ID":"10.1016/j.ijmedinf.2009.08.006",
-                 "IDScheme":"doi",
-                 "IDURL": "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
-              }
-
+      "Title": "The health information system security threat lifecycle: an informatics theory.",
+      "Creator": [
+         {
+            "Name": "Dr Juanita Fernando",
+            "Identifier": [
+               {
+                  "ID": "10.1016/j.ijmedinf.2009.08.006",
+                  "IDScheme": "doi",
+                  "IDURL": "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
+               }
+            ]
          },
-         {  
-            "Name":"Dr Juanita Fernando",
-            "Identifier":{  
-                 "ID":"10.1016/j.ijmedinf.2009.08.006",
-                 "IDScheme":"doi",
-                 "IDURL": "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
-              }
-
+         {
+            "Name": "Dr Juanita Fernando",
+            "Identifier": [
+               {
+                  "ID": "10.1016/j.ijmedinf.2009.08.006",
+                  "IDScheme": "doi",
+                  "IDURL": "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
+               }
+            ]
          }
       ],
-      "PublicationDate":"2017-11-15",
-      "Publisher":[  
-         {  
-            "name":"Monash University",
-             "Identifier":{  
-                 "ID":"10.1016/j.ijmedinf.2009.08.006",
-                 "IDScheme":"doi",
-                 "IDURL": "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
-              }
+      "PublicationDate": "2017-11-15",
+      "Publisher": [
+         {
+            "Name": "Monash University",
+            "Identifier": [
+               {
+                  "ID": "10.1016/j.ijmedinf.2009.08.006",
+                  "IDScheme": "doi",
+                  "IDURL": "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
+               }
+            ]
          }
       ]
    },
-   "Target":{  
-      "Identifier":{  
-         "ID":"10.1016/j.ijmedinf.2009.08.006",
-         "IDScheme":"doi",
+   "Target": {
+      "Identifier": {
+         "ID": "10.1016/j.ijmedinf.2009.08.006",
+         "IDScheme": "doi",
          "IDURL": "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
       },
-      "Type":{  
-         "Name":"publication",
-         "SubType":"journal article",
-         "SubTypeSchema":"CASRAI"
+      "Type": {
+         "Name": "literature",
+         "SubType": "journal article",
+         "SubTypeSchema": "CASRAI"
       },
-      "Title":"The health information system security threat lifecycle: an informatics theory.",
-      "Creator":[  
-         {  
-            "Name":"Dr Juanita Fernando",
-            "Identifier":{  
-                 "ID":"10.1016/j.ijmedinf.2009.08.006",
-                 "IDScheme":"doi",
-                 "IDURL": "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
-              }
-
+      "Title": "The health information system security threat lifecycle: an informatics theory.",
+      "Creator": [
+         {
+            "Name": "Dr Juanita Fernando",
+            "Identifier": [
+               {
+                  "ID": "10.1016/j.ijmedinf.2009.08.006",
+                  "IDScheme": "doi",
+                  "IDURL": "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
+               }
+            ]
          },
-         {  
-            "Name":"Dr Juanita Fernando",
-            "Identifier":{  
-                 "ID":"10.1016/j.ijmedinf.2009.08.006",
-                 "IDScheme":"doi",
-                 "IDURL": "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
-              }
-
+         {
+            "Name": "Dr Juanita Fernando",
+            "Identifier": [
+               {
+                  "ID": "10.1016/j.ijmedinf.2009.08.006",
+                  "IDScheme": "doi",
+                  "IDURL": "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
+               }
+            ]
          }
       ],
-      "PublicationDate":"2017-11-15",
-      "Publisher":[  
-         {  
-            "name":"Monash University",
-             "Identifier":{  
-                 "ID":"10.1016/j.ijmedinf.2009.08.006",
-                 "IDScheme":"doi",
-                 "IDURL": "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
-              }
+      "PublicationDate": "2017-11-15",
+      "Publisher": [
+         {
+            "Name": "Monash University",
+            "Identifier": [
+               {
+                  "ID": "10.1016/j.ijmedinf.2009.08.006",
+                  "IDScheme": "doi",
+                  "IDURL": "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
+               }
+            ]
          }
       ]
    }

--- a/json/v3/schema.json
+++ b/json/v3/schema.json
@@ -6,7 +6,7 @@
   "definitions": {
     "IdentifierType": {
       "type": "object",
-      "description": "Identifier of an object (paper, dataset, person or organization), e.g.: DOI, URL, ISBN, etc.",
+      "description": "Identifier of an object (paper, dataset, person or organization), e.g.: DOI, URL, ISBN, ORCID etc.",
       "additionalProperties": false,
       "properties": {
         "ID": {

--- a/json/v3/schema.json
+++ b/json/v3/schema.json
@@ -1,637 +1,245 @@
 {
-  "definitions": {}, 
-  "$schema": "http://json-schema.org/draft-06/schema#", 
-  "$id": "http://www.scholix.org/schema.json", 
-  "type": "object", 
-  "properties": {
-    "LinkPublicationDate": {
-      "$id": "/properties/LinkPublicationDate", 
-      "type": "string", 
-      "title": "The Linkpublicationdate Schema.", 
-      "description": "Date when  this Link Information Package was first  formally issued from this current Provider", 
-      "default": "", 
-      "examples": [
-        "1997-10-23"
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "http://www.scholix.org/schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "IdentifierType": {
+      "type": "object",
+      "description": "Identifier of an object (paper, dataset, person or organization), e.g.: DOI, URL, ISBN, etc.",
+      "additionalProperties": false,
+      "properties": {
+        "ID": {
+          "type": "string",
+          "title": "Identifier",
+          "description": "The identifier string.",
+          "default": "",
+          "examples": [
+            "475826.a"
+          ]
+        },
+        "IDScheme": {
+          "type": "string",
+          "title": "Identifier's scheme",
+          "description": "Name of the identifier's scheme.",
+          "default": "",
+          "examples": [
+            "grid",
+            "doi",
+            "url"
+          ]
+        },
+        "IDURL": {
+          "type": "string",
+          "title": "Identifier's URL",
+          "description": "Identifier in a URL form.",
+          "default": "",
+          "examples": [
+            "https://grid.ac/institutes/grid.475826.a"
+          ]
+        }
+      },
+      "required": [
+        "ID",
+        "IDScheme"
       ]
-    }, 
-    "LinkProvider": {
-      "$id": "/properties/LinkProvider", 
-      "type": "array",
-      "description": "The source(s) of this Link Information Package",  
-      "items": {
-        "$id": "/properties/LinkProvider/items", 
-        "type": "object", 
-        "properties": {
-          "name": {
-            "$id": "/properties/LinkProvider/items/properties/name", 
-            "type": "string", 
-            "title": "The LinkProvider Name .", 
-            "description": "An explanation about the purpose of this instance.", 
-            "default": "", 
-            "examples": [
-              "Datasets in Datacite"
-            ]
-          }, 
-          "identifier": {
-            "$id": "/properties/LinkProvider/items/properties/identifier", 
-            "type": "array", 
-            "items": {
-              "$id": "/properties/LinkProvider/items/properties/identifier/items", 
-              "type": "object", 
-              "properties": {
-                "ID": {
-                  "$id": "/properties/LinkProvider/items/properties/identifier/items/properties/ID", 
-                  "type": "string", 
-                  "title": "The Id Schema.", 
-                  "description": "An explanation about the purpose of this instance.", 
-                  "default": "", 
-                  "examples": [
-                    "475826.a"
-                  ]
-                }, 
-                "IDScheme": {
-                  "$id": "/properties/LinkProvider/items/properties/identifier/items/properties/IDScheme", 
-                  "type": "string", 
-                  "title": "The Idscheme Schema.", 
-                  "description": "An explanation about the purpose of this instance.", 
-                  "default": "", 
-                  "examples": [
-                    "grid"
-                  ]
-                }, 
-                "IDURL": {
-                  "$id": "/properties/LinkProvider/items/properties/identifier/items/properties/IDURL", 
-                  "type": "string", 
-                  "title": "The Idurl Schema.", 
-                  "description": "An explanation about the purpose of this instance.", 
-                  "default": "", 
-                  "examples": [
-                    "https://grid.ac/institutes/grid.475826.a"
-                  ]
-                }
-              }, 
-              "required": [
-                "ID", 
-                "IDScheme"
-              ]
-            }
-          }
-        }, 
-        "required": [
-          "name"
-        ]
-      }
-    }, 
-    "RelationshipType": {
-      "$id": "/properties/RelationshipType", 
-      "type": "object", 
+    },
+    "DateType": {
+      "type": "string",
+      "title": "Date",
+      "description": "Date as an ISO 8601 standard.",
+      "default": "",
+      "examples": [
+        "2017-11-15",
+        "2017-11-15T13:15:00Z",
+        "2017-11-15T13:15:00+02:00"
+      ]
+    },
+    "PersonOrOrgType": {
+      "description": "An organization or a person.",
+      "type": "object",
+      "additionalProperties": false,
       "properties": {
         "Name": {
-          "$id": "/properties/RelationshipType/properties/Name", 
-          "type": "string", 
+          "type": "string",
+          "title": "Person or organization name.",
+          "description": "The name of an organization or a person.",
+          "default": "",
+          "examples": [
+            "Dr Sandro",
+            "CERN",
+            "Doe, John James"
+          ]
+        },
+        "Identifier": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IdentifierType"
+          }
+        }
+      },
+      "required": [
+        "Name"
+      ]
+    },
+    "ObjectType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Identifier": {
+          "$ref": "#/definitions/IdentifierType",
+          "description": "Identifier of the source or target object."
+        },
+        "Type": {
+          "type": "object",
+          "description": "Type of the object",
+          "additionalProperties": false,
+          "properties": {
+            "Name": {
+              "type": "string",
+              "enum": [
+                "literature",
+                "dataset",
+                "unknown"
+              ],
+              "title": "Object's name",
+              "description": "Name of the object type",
+              "default": "",
+              "examples": [
+                "publication"
+              ]
+            },
+            "SubType": {
+              "type": "string",
+              "title": "Object's subtype",
+              "description": "An explanation about the purpose of this instance.",
+              "default": "",
+              "examples": [
+                "journal article"
+              ]
+            },
+            "SubTypeSchema": {
+              "type": "string",
+              "title": "Object's subtype schema",
+              "description": "An explanation about the purpose of this instance.",
+              "default": "",
+              "examples": [
+                "CASRAI"
+              ]
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "Title": {
+          "type": "string",
+          "title": "The 0 Schema",
+          "description": "An explanation about the purpose of this instance.",
+          "default": "",
+          "examples": [
+            "A Title"
+          ]
+        },
+        "Creator": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PersonOrOrgType"
+          }
+        },
+        "PublicationDate": {
+          "title": "Object publication date",
+          "$ref": "#/definitions/DateType"
+        },
+        "Publisher": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PersonOrOrgType"
+          }
+        }
+      },
+      "required": [
+        "Identifier",
+        "Type"
+      ]
+    }
+  },
+  "properties": {
+    "LinkPublicationDate": {
+      "title": "Link publication date",
+      "$ref": "#/definitions/DateType"
+    },
+    "LinkProvider": {
+      "type": "array",
+      "description": "The source(s) of this Link Information Package",
+      "items": {
+        "$ref": "#/definitions/PersonOrOrgType"
+      }
+    },
+    "RelationshipType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Name": {
+          "type": "string",
           "enum": [
-            "IsSupplementTo", 
-            "IsSupplementedBy", 
-            "References", 
-            "IsReferencedBy", 
+            "IsSupplementTo",
+            "IsSupplementedBy",
+            "References",
+            "IsReferencedBy",
             "IsRelatedTo"
-          ], 
-          "title": "The Name Schema.", 
-          "description": "An explanation about the purpose of this instance.", 
-          "default": "", 
+          ],
+          "title": "Relationship name",
+          "description": "The name of the relationship type.",
+          "default": "",
           "examples": [
             "IsRelatedTo"
           ]
-        }, 
+        },
         "SubType": {
-          "$id": "/properties/RelationshipType/properties/SubType", 
-          "type": "string", 
-          "title": "The Subtype Schema.", 
-          "description": "An explanation about the purpose of this instance.", 
-          "default": "", 
+          "type": "string",
+          "title": "Relationship subtype",
+          "description": "The name of the relationship subtype.",
+          "default": "",
           "examples": [
             "isPreviousVersionOf"
           ]
-        }, 
+        },
         "SubTypeSchema": {
-          "$id": "/properties/RelationshipType/properties/SubTypeSchema", 
-          "type": "string", 
-          "title": "The Subtypeschema Schema.", 
-          "description": "An explanation about the purpose of this instance.", 
-          "default": "", 
+          "type": "string",
+          "title": "Relationship subtype schema",
+          "description": "Schema of the relationship's subtype.",
+          "default": "",
           "examples": [
             "https://schema.datacite.org/meta/kernel-4.0/metadata.xsd"
           ]
         }
-      }, 
+      },
       "required": [
         "Name"
       ]
-    }, 
+    },
     "LicenseURL": {
-      "$id": "/properties/LicenseURL", 
-      "type": "string", 
-      "title": "The Licenseurl Schema.", 
-      "description": "An explanation about the purpose of this instance.", 
-      "default": "", 
+      "type": "string",
+      "title": "License URL schema",
+      "description": "URL to the license of this Link Information Package.",
+      "default": "",
       "examples": [
         "http://creativecommons.org/publicdomain/zero/1.0"
       ]
-    }, 
+    },
     "Source": {
-      "$id": "/properties/Source", 
-      "type": "object", 
-      "properties": {
-        "Identifier": {
-          "$id": "/properties/Source/properties/Identifier", 
-          "type": "object", 
-          "properties": {
-            "ID": {
-              "$id": "/properties/Source/properties/Identifier/properties/ID", 
-              "type": "string", 
-              "title": "The Id Schema.", 
-              "description": "An explanation about the purpose of this instance.", 
-              "default": "", 
-              "examples": [
-                "10.1016/j.ijmedinf.2009.08.006"
-              ]
-            }, 
-            "IDScheme": {
-              "$id": "/properties/Source/properties/Identifier/properties/IDScheme", 
-              "type": "string", 
-              "title": "The Idscheme Schema.", 
-              "description": "An explanation about the purpose of this instance.", 
-              "default": "", 
-              "examples": [
-                "doi"
-              ]
-            }, 
-            "IDURL": {
-              "$id": "/properties/Source/properties/Identifier/properties/IDURL", 
-              "type": "string", 
-              "title": "The Idurl Schema.", 
-              "description": "An explanation about the purpose of this instance.", 
-              "default": "", 
-              "examples": [
-                "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
-              ]
-            }
-          }, 
-          "required": [
-            "ID", 
-            "IDScheme"
-          ]
-        }, 
-        "Type": {
-          "$id": "/properties/Source/properties/Type", 
-          "type": "object", 
-          "properties": {
-            "Name": {
-              "$id": "/properties/Source/properties/Type/properties/Name", 
-              "type": "string", 
-              "enum": [
-                "literature", 
-                "dataset",
-                "unknwon"
-              ], 
-              "title": "The Name Schema.", 
-              "description": "An explanation about the purpose of this instance.", 
-              "default": "", 
-              "examples": [
-                "publication"
-              ]
-            }, 
-            "SubType": {
-              "$id": "/properties/Source/properties/Type/properties/SubType", 
-              "type": "string", 
-              "title": "The Subtype Schema.", 
-              "description": "An explanation about the purpose of this instance.", 
-              "default": "", 
-              "examples": [
-                "journal article"
-              ]
-            }, 
-            "SubTypeSchema": {
-              "$id": "/properties/Source/properties/Type/properties/SubTypeSchema", 
-              "type": "string", 
-              "title": "The Subtypeschema Schema.", 
-              "description": "An explanation about the purpose of this instance.", 
-              "default": "", 
-              "examples": [
-                "CASRAI"
-              ]
-            }
-          }, 
-          "required": [
-            "Name"
-          ]
-        }, 
-        "Title": {
-          "$id": "/properties/Source/properties/Title", 
-          "type": "array", 
-          "items": {
-            "$id": "/properties/Target/properties/Title/items", 
-            "type": "string", 
-            "title": "The 0 Schema.", 
-            "description": "An explanation about the purpose of this instance.", 
-            "default": "", 
-            "examples": [
-              "A Title"
-            ]
-          }
-        }, 
-        "Creator": {
-          "$id": "/properties/Source/properties/Creator", 
-          "type": "array", 
-          "items": {
-            "$id": "/properties/Source/properties/Creator/items", 
-            "type": "object", 
-            "properties": {
-              "Name": {
-                "$id": "/properties/Source/properties/Creator/items/properties/Name", 
-                "type": "string", 
-                "title": "The Name Schema.", 
-                "description": "An explanation about the purpose of this instance.", 
-                "default": "", 
-                "examples": [
-                  "Dr Sandro"
-                ]
-              }, 
-              "Identifier": {
-                "$id": "/properties/Source/properties/Creator/items/properties/Identifier", 
-                "type": "object", 
-                "properties": {
-                  "ID": {
-                    "$id": "/properties/Source/properties/Creator/items/properties/Identifier/properties/ID", 
-                    "type": "string", 
-                    "title": "The Id Schema.", 
-                    "description": "An explanation about the purpose of this instance.", 
-                    "default": "", 
-                    "examples": [
-                      "10.1016/j.ijmedinf.2009.08.006"
-                    ]
-                  }, 
-                  "IDScheme": {
-                    "$id": "/properties/Source/properties/Creator/items/properties/Identifier/properties/IDScheme", 
-                    "type": "string", 
-                    "title": "The Idscheme Schema.", 
-                    "description": "An explanation about the purpose of this instance.", 
-                    "default": "", 
-                    "examples": [
-                      "doi"
-                    ]
-                  }, 
-                  "IDURL": {
-                    "$id": "/properties/Source/properties/Creator/items/properties/Identifier/properties/IDURL", 
-                    "type": "string", 
-                    "title": "The Idurl Schema.", 
-                    "description": "An explanation about the purpose of this instance.", 
-                    "default": "", 
-                    "examples": [
-                      "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
-                    ]
-                  }
-                }, 
-                "required": [
-                  "ID", 
-                  "IDScheme"
-                ]
-              }
-            }, 
-            "required": [
-              "Name"
-            ]
-          }
-        }, 
-        "PublicationDate": {
-          "$id": "/properties/Source/properties/PublicationDate", 
-          "type": "string", 
-          "title": "The Publicationdate Schema.", 
-          "description": "An explanation about the purpose of this instance.", 
-          "default": "", 
-          "examples": [
-            "2017-11-15"
-          ]
-        }, 
-        "Publisher": {
-          "$id": "/properties/Source/properties/Publisher", 
-          "type": "array", 
-          "items": {
-            "$id": "/properties/Source/properties/Publisher/items", 
-            "type": "object", 
-            "properties": {
-              "name": {
-                "$id": "/properties/Source/properties/Publisher/items/properties/name", 
-                "type": "string", 
-                "title": "The Name Schema.", 
-                "description": "An explanation about the purpose of this instance.", 
-                "default": "", 
-                "examples": [
-                  "Monash University"
-                ]
-              }, 
-              "Identifier": {
-                "$id": "/properties/Source/properties/Publisher/items/properties/Identifier", 
-                "type": "object", 
-                "properties": {
-                  "ID": {
-                    "$id": "/properties/Source/properties/Publisher/items/properties/Identifier/properties/ID", 
-                    "type": "string", 
-                    "title": "The Id Schema.", 
-                    "description": "An explanation about the purpose of this instance.", 
-                    "default": "", 
-                    "examples": [
-                      "10.1016/j.ijmedinf.2009.08.006"
-                    ]
-                  }, 
-                  "IDScheme": {
-                    "$id": "/properties/Source/properties/Publisher/items/properties/Identifier/properties/IDScheme", 
-                    "type": "string", 
-                    "title": "The Idscheme Schema.", 
-                    "description": "An explanation about the purpose of this instance.", 
-                    "default": "", 
-                    "examples": [
-                      "doi"
-                    ]
-                  }, 
-                  "IDURL": {
-                    "$id": "/properties/Source/properties/Publisher/items/properties/Identifier/properties/IDURL", 
-                    "type": "string", 
-                    "title": "The Idurl Schema.", 
-                    "description": "An explanation about the purpose of this instance.", 
-                    "default": "", 
-                    "examples": [
-                      "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
-                    ]
-                  }
-                }, 
-                "required": [
-                  "ID", 
-                  "IDScheme"
-                ]
-              }
-            }, 
-            "required": [
-              "name"
-            ]
-          }
-        }
-      }, 
-      "required": [
-        "Identifier", 
-        "Type"
-      ]
-    }, 
+      "$ref": "#/definitions/ObjectType"
+    },
     "Target": {
-      "$id": "/properties/Target", 
-      "type": "object", 
-      "properties": {
-        "Identifier": {
-          "$id": "/properties/Target/properties/Identifier", 
-          "type": "object", 
-          "properties": {
-            "ID": {
-              "$id": "/properties/Target/properties/Identifier/properties/ID", 
-              "type": "string", 
-              "title": "The Id Schema.", 
-              "description": "An explanation about the purpose of this instance.", 
-              "default": "", 
-              "examples": [
-                "10.1016/j.ijmedinf.2009.08.006"
-              ]
-            }, 
-            "IDScheme": {
-              "$id": "/properties/Target/properties/Identifier/properties/IDScheme", 
-              "type": "string", 
-              "title": "The Idscheme Schema.", 
-              "description": "An explanation about the purpose of this instance.", 
-              "default": "", 
-              "examples": [
-                "doi"
-              ]
-            }, 
-            "IDURL": {
-              "$id": "/properties/Target/properties/Identifier/properties/IDURL", 
-              "type": "string", 
-              "title": "The Idurl Schema.", 
-              "description": "An explanation about the purpose of this instance.", 
-              "default": "", 
-              "examples": [
-                "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
-              ]
-            }
-          }, 
-          "required": [
-            "ID", 
-            "IDScheme"
-          ]
-        }, 
-        "Type": {
-          "$id": "/properties/Target/properties/Type", 
-          "type": "object", 
-          "properties": {
-            "Name": {
-              "$id": "/properties/Target/properties/Type/properties/Name", 
-              "type": "string", 
-              "enum": [
-                "literature", 
-                "dataset",
-                "unknwon"
-              ], 
-              "title": "The Name Schema.", 
-              "description": "An explanation about the purpose of this instance.", 
-              "default": "", 
-              "examples": [
-                "publication"
-              ]
-            }, 
-            "SubType": {
-              "$id": "/properties/Target/properties/Type/properties/SubType", 
-              "type": "string", 
-              "title": "The Subtype Schema.", 
-              "description": "An explanation about the purpose of this instance.", 
-              "default": "", 
-              "examples": [
-                "journal article"
-              ]
-            }, 
-            "SubTypeSchema": {
-              "$id": "/properties/Target/properties/Type/properties/SubTypeSchema", 
-              "type": "string", 
-              "title": "The Subtypeschema Schema.", 
-              "description": "An explanation about the purpose of this instance.", 
-              "default": "", 
-              "examples": [
-                "CASRAI"
-              ]
-            }
-          }, 
-          "required": [
-            "Name"
-          ]
-        }, 
-        "Title": {
-          "$id": "/properties/Target/properties/Title", 
-          "type": "array", 
-          "items": {
-            "$id": "/properties/Target/properties/Title/items", 
-            "type": "string", 
-            "title": "The 0 Schema.", 
-            "description": "An explanation about the purpose of this instance.", 
-            "default": "", 
-            "examples": [
-              "A Title"
-            ]
-          }
-        }, 
-        "Creator": {
-          "$id": "/properties/Target/properties/Creator", 
-          "type": "array", 
-          "items": {
-            "$id": "/properties/Target/properties/Creator/items", 
-            "type": "object", 
-            "properties": {
-              "Name": {
-                "$id": "/properties/Target/properties/Creator/items/properties/Name", 
-                "type": "string", 
-                "title": "The Name Schema.", 
-                "description": "An explanation about the purpose of this instance.", 
-                "default": "", 
-                "examples": [
-                  "Dr Fernando"
-                ]
-              }, 
-              "Identifier": {
-                "$id": "/properties/Target/properties/Creator/items/properties/Identifier", 
-                "type": "object", 
-                "properties": {
-                  "ID": {
-                    "$id": "/properties/Target/properties/Creator/items/properties/Identifier/properties/ID", 
-                    "type": "string", 
-                    "title": "The Id Schema.", 
-                    "description": "An explanation about the purpose of this instance.", 
-                    "default": "", 
-                    "examples": [
-                      "10.1016/j.ijmedinf.2009.08.006"
-                    ]
-                  }, 
-                  "IDScheme": {
-                    "$id": "/properties/Target/properties/Creator/items/properties/Identifier/properties/IDScheme", 
-                    "type": "string", 
-                    "title": "The Idscheme Schema.", 
-                    "description": "An explanation about the purpose of this instance.", 
-                    "default": "", 
-                    "examples": [
-                      "doi"
-                    ]
-                  }, 
-                  "IDURL": {
-                    "$id": "/properties/Target/properties/Creator/items/properties/Identifier/properties/IDURL", 
-                    "type": "string", 
-                    "title": "The Idurl Schema.", 
-                    "description": "An explanation about the purpose of this instance.", 
-                    "default": "", 
-                    "examples": [
-                      "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
-                    ]
-                  }
-                }, 
-                "required": [
-                  "ID", 
-                  "IDScheme"
-                ]
-              }
-            }, 
-            "required": [
-              "Name"
-            ]
-          }
-        }, 
-        "PublicationDate": {
-          "$id": "/properties/Target/properties/PublicationDate", 
-          "type": "string", 
-          "title": "The Publicationdate Schema.", 
-          "description": "An explanation about the purpose of this instance.", 
-          "default": "", 
-          "examples": [
-            "2017-11-15"
-          ]
-        }, 
-        "Publisher": {
-          "$id": "/properties/Target/properties/Publisher", 
-          "type": "array", 
-          "items": {
-            "$id": "/properties/Target/properties/Publisher/items", 
-            "type": "object", 
-            "properties": {
-              "name": {
-                "$id": "/properties/Target/properties/Publisher/items/properties/name", 
-                "type": "string", 
-                "title": "The Name Schema.", 
-                "description": "An explanation about the purpose of this instance.", 
-                "default": "", 
-                "examples": [
-                  "Monash University"
-                ]
-              }, 
-              "Identifier": {
-                "$id": "/properties/Target/properties/Publisher/items/properties/Identifier", 
-                "type": "object", 
-                "properties": {
-                  "ID": {
-                    "$id": "/properties/Target/properties/Publisher/items/properties/Identifier/properties/ID", 
-                    "type": "string", 
-                    "title": "The Id Schema.", 
-                    "description": "An explanation about the purpose of this instance.", 
-                    "default": "", 
-                    "examples": [
-                      "10.1016/j.ijmedinf.2009.08.006"
-                    ]
-                  }, 
-                  "IDScheme": {
-                    "$id": "/properties/Target/properties/Publisher/items/properties/Identifier/properties/IDScheme", 
-                    "type": "string", 
-                    "title": "The Idscheme Schema.", 
-                    "description": "An explanation about the purpose of this instance.", 
-                    "default": "", 
-                    "examples": [
-                      "doi"
-                    ]
-                  }, 
-                  "IDURL": {
-                    "$id": "/properties/Target/properties/Publisher/items/properties/Identifier/properties/IDURL", 
-                    "type": "string", 
-                    "title": "The Idurl Schema.", 
-                    "description": "An explanation about the purpose of this instance.", 
-                    "default": "", 
-                    "examples": [
-                      "https://www.ncbi.nlm.nih.gov/pubmed/19783203"
-                    ]
-                  }
-                }, 
-                "required": [
-                  "ID", 
-                  "IDScheme"
-                ]
-              }
-            }, 
-            "required": [
-              "name"
-            ]
-          }
-        }
-      }, 
-      "required": [
-        "Identifier", 
-        "Type"
-      ]
+      "$ref": "#/definitions/ObjectType"
     }
-  }, 
+  },
   "required": [
-    "LinkPublicationDate", 
-    "LinkProvider", 
-    "RelationshipType", 
-    "Source", 
+    "LinkPublicationDate",
+    "LinkProvider",
+    "RelationshipType",
+    "Source",
     "Target"
   ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+jsonschema==2.6.0
+pytest==3.2.3
+jinja2==2.9.6

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+"""Tests configuration."""
+import pytest
+import os
+import json
+
+@pytest.fixture
+def test_dir():
+    """Test directory."""
+    return os.path.dirname(__file__)
+
+
+@pytest.fixture
+def data_dir(test_dir):
+    """Test data directory."""
+    return os.path.join(test_dir, 'data')
+
+
+@pytest.fixture
+def jsonschema_dir(test_dir):
+    """JSON schemas directory."""
+    return os.path.join(test_dir, '..', 'json')
+
+
+def load_json_schema(basedir, filename):
+    """Helper function for loading JSON schemas."""
+    with open(os.path.join(basedir, filename)) as fp:
+        schema = json.load(fp)
+    return schema
+
+
+@pytest.fixture
+def json_schema_v3(jsonschema_dir):
+    """Scholix JSON Schema v3."""
+    return load_json_schema(os.path.join(jsonschema_dir, 'v3'), 'schema.json')
+
+
+@pytest.fixture
+def json_example_v3(jsonschema_dir):
+    """Example of JSON under Scholix JSON Schema v3."""
+    return load_json_schema(os.path.join(jsonschema_dir, 'v3', 'example'),
+                            'example.json')

--- a/tests/test_jsonschema_v3.py
+++ b/tests/test_jsonschema_v3.py
@@ -1,0 +1,8 @@
+"""Test example JSON document against the JSONSchema."""
+from jsonschema import validate
+
+
+def test_json_example(json_schema_v3, json_example_v3):
+    """Test simple relation event JSONSchema validation."""
+    # Will rase in case of schema validation errors
+    validate(json_example_v3, json_schema_v3)


### PR DESCRIPTION
* Refactors the JSON Schema to re-use definitions.

* Fixes LinkProvider 'name' and 'identifier' case.

* Fixes enum in ObjectType ('unknown').

* Fixes formatting and some data for the example JSON document.

* Adds unit test for the example document.

Signed-off-by: Krzysztof Nowak <k.nowak@cern.ch>