### PR TITLE
Updated maxOccur for LinkProvider to unbounded as per documentation

### DIFF
--- a/xsd/v3/schema.xsd
+++ b/xsd/v3/schema.xsd
@@ -19,7 +19,7 @@
                 </xs:annotation>
             </xs:element>
             
-            <xs:element minOccurs="1" maxOccurs="1" name="LinkProvider" type="scholix:providerType">
+            <xs:element minOccurs="1" maxOccurs="unbounded" name="LinkProvider" type="scholix:providerType">
                 <xs:annotation>
                     <xs:documentation>
                         An entity responsible for making the link available


### PR DESCRIPTION
According to the provided document and the json schema, the LinkProvider should be a 1..N occurrence, however, the xml schema does not reflect that.